### PR TITLE
Use explicit version for node image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     working_dir: "/srv"
     volumes: [".:/srv"]
   node:
-    image: node
+    image: node:25
     container_name: "interpretation-node"
     user: "${UID}:${GID}"
     working_dir: "/srv"


### PR DESCRIPTION
> The [Yarn v1 Classic](https://classic.yarnpkg.com/) package manager is bundled in node image variants that include Node.js versions 25 and below.

Ref: https://github.com/nodejs/docker-node/blob/main/README.md#yarn-v1-classic-bundling